### PR TITLE
References nonexistent CSS file.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -61,10 +61,6 @@ Options are provided to hide certain sections/fields/features from displaying in
 
 @define('hive_theme_hide_tag_builder_column', true);@
 
-*Hide form preview button (forms page):*
-
-@define('hive_theme_hide_form_preview', true);@
-
 h2. Development details
 
 Supported browsers: Google Chrome 12+, Internet Explorer 8+, Mozilla Firefox 4+, Apple Safari 5+ and Opera 10+. Development environment requires <a href="http://sass-lang.com" rel="external" title="Go to the Sass website">Sass</a> 3.2+ and <a href="http://compass-style.org" rel="external" title="Go to the Compass website">Compass</a> 0.12.2+, plus the Compass extension <a href="http://singularity.gs" rel="external" title="Go to the Singularity website">Singularity</a> 1.0+.

--- a/hive.php
+++ b/hive.php
@@ -86,10 +86,6 @@ class hive_theme extends theme
 		{
 			$out[] = '<link rel="stylesheet" href="'.$this->url.'css/custom/hide_tag_builder_column.css">';
 		}
-		if (defined('hive_theme_hide_form_preview'))
-		{
-			$out[] = '<link rel="stylesheet" href="'.$this->url.'css/custom/hide_form_preview.css">';
-		}
 		// End of custom CSS toggles.
 
 		$out[] = '<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">';


### PR DESCRIPTION
Left over from an custom CSS toggle. hide_form_preview.css is gone as of the introduction of the simple preview and duplication links.
